### PR TITLE
Fix some configuration to build and run Komet via JPro using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ COPY . /komet/
 WORKDIR /komet/
 
 RUN ls /komet/
-RUN ./mvnw clean install -Pjpro
+RUN ./mvnw clean install -Dmaven.javadoc.skip=true -Dmaven.test.skip=true
+RUN ./mvnw clean -f application -Pjpro jpro:release
 
 FROM azul/zulu-openjdk-alpine:23-latest
 
@@ -17,7 +18,8 @@ RUN apk add --no-cache libc6-compat gtk+3.0
 
 # Copy the JPro application to the image
 COPY --from=builder /komet/application/target/komet-jpro.zip /komet-jpro.zip
-COPY docker/jpro/html/ /jproserver/komet-jpro/html/
+
+# Unzip the JPro application
 RUN unzip /komet-jpro.zip -d /jproserver/
 
 WORKDIR /jproserver/komet-jpro/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   nexus:
     image: sonatype/nexus3
@@ -16,7 +14,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - komet-data:/root/Solor
+      - ~/Solor:/root/Solor
     networks:
       - rapidenv
     restart: unless-stopped

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,13 +1,24 @@
-proxy_buffering    off;
-proxy_set_header   X-Real-IP $remote_addr;
-proxy_set_header   X-Forwarded-Proto $scheme;
-proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-proxy_set_header   Host $http_host;
-proxy_set_header   Upgrade $http_upgrade;
-proxy_set_header   Connection "upgrade";
-proxy_read_timeout 86400;
-proxy_http_version 1.1;
+server {
+    listen 80;
+    server_name localhost; # Adjust this to your hostname
 
-upstream komet {
-  server 127.0.0.1:8080;
+    location /nexus/ {
+        proxy_pass http://nexus:8081/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /komet/ {
+        proxy_buffering    off;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   Host $http_host;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_read_timeout 86400;
+        proxy_http_version 1.1;
+    }
 }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,28 +1,13 @@
-events {}
+proxy_buffering    off;
+proxy_set_header   X-Real-IP $remote_addr;
+proxy_set_header   X-Forwarded-Proto $scheme;
+proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header   Host $http_host;
+proxy_set_header   Upgrade $http_upgrade;
+proxy_set_header   Connection "upgrade";
+proxy_read_timeout 86400;
+proxy_http_version 1.1;
 
-http {
-    server {
-        listen 80;
-        server_name localhost; # Adjust this to your hostname
-
-        location /nexus/ {
-            proxy_pass http://nexus:8081/;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-
-;         location /komet/ {
-;             proxy_pass http://komet:8080/;
-;             proxy_set_header   Host $host;
-;             proxy_set_header   X-Real-IP $remote_addr;
-;             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-;             proxy_set_header   X-Forwarded-Proto $scheme;
-;             proxy_set_header   Upgrade $http_upgrade;
-;             proxy_set_header   Connection "upgrade";
-;             proxy_read_timeout 86400;
-;             proxy_http_version 1.1;
-;         }
-    }
+upstream komet {
+  server 127.0.0.1:8080;
 }


### PR DESCRIPTION
Some small corrections to run Komet with JPro with the docker configuration changes present in the parent `nexus` branch.